### PR TITLE
Added support for using this framework with QuickContactBadges

### DIFF
--- a/src/com/loopj/android/image/SmartQuickContactBadge.java
+++ b/src/com/loopj/android/image/SmartQuickContactBadge.java
@@ -1,0 +1,104 @@
+package com.loopj.android.image;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ExecutorService;
+
+import android.content.Context;
+import android.graphics.Bitmap;
+import android.widget.QuickContactBadge;
+import android.util.AttributeSet;
+
+public class SmartQuickContactBadge extends QuickContactBadge {
+    private static final int LOADING_THREADS = 10;
+    private static ExecutorService threadPool = Executors.newFixedThreadPool(LOADING_THREADS);
+
+    private SmartImageTask currentTask;
+
+
+    public SmartQuickContactBadge(Context context) {
+        super(context);
+    }
+
+    public SmartQuickContactBadge(Context context, AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    public SmartQuickContactBadge(Context context, AttributeSet attrs, int defStyle) {
+        super(context, attrs, defStyle);
+    }
+
+
+    // Helpers to set image by URL
+    public void setImageUrl(String url) {
+        setImage(new WebImage(url));
+    }
+
+    public void setImageUrl(String url, final Integer fallbackResource) {
+        setImage(new WebImage(url), fallbackResource);
+    }
+
+    public void setImageUrl(String url, final Integer fallbackResource, final Integer loadingResource) {
+        setImage(new WebImage(url), fallbackResource, loadingResource);
+    }
+
+
+    // Helpers to set image by contact address book id
+    public void setImageContact(long contactId) {
+        setImage(new ContactImage(contactId));
+    }
+
+    public void setImageContact(long contactId, final Integer fallbackResource) {
+        setImage(new ContactImage(contactId), fallbackResource);
+    }
+
+    public void setImageContact(long contactId, final Integer fallbackResource, final Integer loadingResource) {
+        setImage(new ContactImage(contactId), fallbackResource, fallbackResource);
+    }
+
+
+    // Set image using SmartImage object
+    public void setImage(final SmartImage image) {
+        setImage(image, null, null);
+    }
+
+    public void setImage(final SmartImage image, final Integer fallbackResource) {
+        setImage(image, fallbackResource, fallbackResource);
+    }
+
+    public void setImage(final SmartImage image, final Integer fallbackResource, final Integer loadingResource) {
+        // Set a loading resource
+        if(loadingResource != null){
+            setImageResource(loadingResource);
+        }
+
+        // Cancel any existing tasks for this image view
+        if(currentTask != null) {
+            currentTask.cancel();
+            currentTask = null;
+        }
+
+        // Set up the new task
+        currentTask = new SmartImageTask(getContext(), image);
+        currentTask.setOnCompleteHandler(new SmartImageTask.OnCompleteHandler() {
+            @Override
+            public void onComplete(Bitmap bitmap) {
+                if(bitmap != null) {
+                    setImageBitmap(bitmap);
+                } else {
+                    // Set fallback resource
+                    if(fallbackResource != null) {
+                        setImageResource(fallbackResource);
+                    }
+                }
+            }
+        });
+
+        // Run the task in a threadpool
+        threadPool.execute(currentTask);
+    }
+
+    public static void cancelAllTasks() {
+        threadPool.shutdownNow();
+        threadPool = Executors.newFixedThreadPool(LOADING_THREADS);
+    }
+}


### PR DESCRIPTION
Created new SmartQuickContactBadge that can be created instead of SmartImageView to provide QuickContactBadge instead of a regular ImageView,

To use just change SmartImageView to SmartQuickContactBadge in the XML layout, as well as when creating it in code.
