### PR TITLE
Added support to get handle of bitmap on image load complete

### DIFF
--- a/src/com/loopj/android/image/SmartImageTask.java
+++ b/src/com/loopj/android/image/SmartImageTask.java
@@ -25,6 +25,14 @@ public class SmartImageTask implements Runnable {
 
     public abstract static class OnCompleteListener {
         public abstract void onComplete();
+        /***
+        *  Convient method to get Bitmap after image is loaded.
+        *  Override this method to get handle of bitmap
+        *  Added overloaded implementation to make it backward compatible with previous versions
+        */
+        public void onComplete(Bitmap bitmap){
+            onComplete();
+        }
     }
 
     public SmartImageTask(Context context, SmartImage image) {

--- a/src/com/loopj/android/image/SmartImageView.java
+++ b/src/com/loopj/android/image/SmartImageView.java
@@ -116,7 +116,7 @@ public class SmartImageView extends ImageView {
                 }
 
                 if(completeListener != null){
-                    completeListener.onComplete();
+                    completeListener.onComplete(bitmap);
                 }
             }
         });


### PR DESCRIPTION
Hi @loopj

I have added support in OnCompleteListener to get reference(handle) of bitmap with onComplete(Bitmap).
Also taken care of backward compatibility of old api call onComplete().

I think having a way to get referece of bitmap will be handy for other applications.
